### PR TITLE
Fix shell nav service: circular flow between shell & login nav

### DIFF
--- a/src/Jellyfin.Maui/Services/ShellNavigationService.cs
+++ b/src/Jellyfin.Maui/Services/ShellNavigationService.cs
@@ -87,6 +87,7 @@ public class ShellNavigationService : INavigationService
         {
             if (Shell is null)
             {
+                _loginNavigationPage = null;
                 _application.MainPage = InternalServiceProvider.GetService<AppShell>();
             }
             else


### PR DESCRIPTION
Fix shell nav service: circular flow between shell & login nav causes a crash.